### PR TITLE
[TIPS] forward requests from proxyd to ingress rpc

### DIFF
--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -766,6 +766,13 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 		httpReq.Header.Set(name, value)
 	}
 
+	// Send async copy to ingress service
+	go func() {
+		ingressReq, _ := http.NewRequest("POST", "http://localhost:3000", bytes.NewReader(body))
+		ingressReq.Header.Set("content-type", "application/json")
+		http.DefaultClient.Do(ingressReq)
+	}()
+
 	start := time.Now()
 	httpRes, err := b.client.DoLimited(httpReq)
 	if err != nil {

--- a/proxyd/backend.go
+++ b/proxyd/backend.go
@@ -303,6 +303,7 @@ type Backend struct {
 	maxWSConns           int
 	outOfServiceInterval time.Duration
 	stripTrailingXFF     bool
+	ingressRPC           string
 	proxydIP             string
 
 	skipIsSyncingCheck bool
@@ -451,6 +452,12 @@ func WithMaxErrorRateThreshold(maxErrorRateThreshold float64) BackendOpt {
 func WithConsensusReceiptTarget(receiptsTarget string) BackendOpt {
 	return func(b *Backend) {
 		b.receiptsTarget = receiptsTarget
+	}
+}
+
+func WithIngressRPC(ingressRPC string) BackendOpt {
+	return func(b *Backend) {
+		b.ingressRPC = ingressRPC
 	}
 }
 
@@ -766,12 +773,19 @@ func (b *Backend) doForward(ctx context.Context, rpcReqs []*RPCReq, isBatch bool
 		httpReq.Header.Set(name, value)
 	}
 
-	// Send async copy to ingress service
-	go func() {
-		ingressReq, _ := http.NewRequest("POST", "http://localhost:3000", bytes.NewReader(body))
-		ingressReq.Header.Set("content-type", "application/json")
-		http.DefaultClient.Do(ingressReq)
-	}()
+	if b.ingressRPC != "" {
+		// Send async copy to ingress service, don't wait for error handling
+		go func() {
+			ingressReq, _ := http.NewRequestWithContext(ctx, "POST", b.ingressRPC, bytes.NewReader(body))
+			ingressReq.Header.Set("content-type", "application/json")
+			ingressReq.Header.Set("X-Forwarded-For", xForwardedFor)
+			for name, value := range b.headers {
+				ingressReq.Header.Set(name, value)
+			}
+			httpRes, _ := http.DefaultClient.Do(ingressReq)
+			httpRes.Body.Close()
+		}()
+	}
 
 	start := time.Now()
 	httpRes, err := b.client.DoLimited(httpReq)


### PR DESCRIPTION
<!-- Contributions welcome! See https://github.com/ethereum-optimism/.github/blob/master/CONTRIBUTING.md -->

**Description**

Enable proxyd to also forward requests to ingress RPC async. Specifically, do not wait for errors / responses.

**Tests**

**Additional context**

**Metadata**
